### PR TITLE
Fix NOT_RESTRICTED network capability and enforce it.

### DIFF
--- a/src/java/com/android/internal/telephony/dataconnection/DataConnection.java
+++ b/src/java/com/android/internal/telephony/dataconnection/DataConnection.java
@@ -978,7 +978,7 @@ public final class DataConnection extends StateMachine {
                     result.removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
                 }
             }
-            ConnectivityManager.maybeMarkCapabilitiesRestricted(result);
+            result.maybeMarkCapabilitiesRestricted();
         }
         int up = 14;
         int down = 14;


### PR DESCRIPTION
With this change:
1. NOT_RESTRICTED should be removed from NetworkRequests that bring up
   special restricted carrier networks (e.g. IMS, FOTA).
2. NetworkRequests without NOT_RESTRICTED require CONNECTIVITY_INTERNAL
   permission to register
3. Binding sockets to networks without NOT_RESTRICTED requires
   CONNECTIVITY_INTERNAL permission

Bug:21637535
(cherry picked from commit af171aa4dcf294bf2d1b9bed54ef9a6b0ec76361)

Resolved conflicts from cherry-picking ag/758371 into the lmp-mr1-release branch.

Change-Id: I5991d39facaa6b690e969fe15dcbeec52e918321
