### PR TITLE
Revert "Fix HD icon shown for MO VoLTE call when it shouldn't"

### DIFF
--- a/src/java/com/android/internal/telephony/imsphone/ImsPhoneConnection.java
+++ b/src/java/com/android/internal/telephony/imsphone/ImsPhoneConnection.java
@@ -673,10 +673,8 @@ public class ImsPhoneConnection extends Connection {
         boolean updateWifiState = updateWifiState();
         boolean updateAddressDisplay = updateAddressDisplay(imsCall);
         boolean updateExtras = updateExtras(imsCall);
-        boolean updateMediaCapabilities = updateMediaCapabilities(imsCall);
 
-        return updateParent || updateMediaCapabilities || updateWifiState || updateAddressDisplay
-                || updateExtras;
+        return updateParent || updateWifiState || updateAddressDisplay || updateExtras;
     }
 
     @Override


### PR DESCRIPTION
This reverts commit 309bfd91645d4da1a7becbf2e6b2dc3f865ca0b5.

Change-Id: I5da64fd85283d57d667702d04591aa1b1deebe30
Signed-off-by: Josue Rivera prbassplayer@gmail.com
